### PR TITLE
Always inhibit operator code when canceling an exchange

### DIFF
--- a/evil-exchange.el
+++ b/evil-exchange.el
@@ -169,6 +169,8 @@
 (defun evil-exchange-cancel ()
   "Cancel current pending exchange."
   (interactive)
+  (when evil-this-operator
+    (setq evil-inhibit-operator t))
   (if (null evil-exchange--position)
       (message "No pending exchange")
     (evil-exchange--clean)


### PR DESCRIPTION
When `evil-exchange` is triggered through the `cx` keybinding, and
then canceled with `c`, this function runs and eventually evil treats
the result as a trivial motion to pass through to the rest of the
operator code.

Since we're canceling the exchange, we never want the rest of the
`evil-exchange` code to run, so we have to explicitly cancel it here.

Fixes #14.