### PR TITLE
Add NonGNU ELPA badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![NonGNU ELPA](https://elpa.nongnu.org/nongnu/evil-exchange.svg)](https://elpa.nongnu.org/nongnu/evil-exchange.html)
 [![MELPA](https://melpa.org/packages/evil-exchange-badge.svg)](https://melpa.org/#/evil-exchange)
 [![Build Status](https://travis-ci.org/Dewdrops/evil-exchange.png?branch=master)](https://travis-ci.org/Dewdrops/evil-exchange)
 


### PR DESCRIPTION
This package is now on NonGNU ELPA! This commit adds a badge because it looks nice and is occasionally useful. Thanks.